### PR TITLE
🥑 refactor: padronizar BASE_URL e USER_AGENT

### DIFF
--- a/abacatepay/__init__.py
+++ b/abacatepay/__init__.py
@@ -22,7 +22,7 @@ from typing import Literal
 
 from .billing import Billing
 from ._models import Product, BillingResponse, Customer
-from ._constants import BILLING_KINDS, BILLING_METHODS, BASEURL, USERAGENT
+from ._constants import BILLING_KINDS, BILLING_METHODS, BASE_URL, USERAGENT
 from ._exceptions import *
 
 
@@ -75,8 +75,8 @@ class AbacatePay:
         )
 
     def list_bills(self) -> list[Billing]:
-        logger.debug(f"Listing bills with URL: {BASEURL}/billing/list")
-        response = self._request(f"{BASEURL}/billing/list", method="GET")
+        logger.debug(f"Listing bills with URL: {BASE_URL}/billing/list")
+        response = self._request(f"{BASE_URL}/billing/list", method="GET")
 
         try:
             if response.status_code == 200:
@@ -90,8 +90,8 @@ class AbacatePay:
 
 
     def create_customer(self, customer: Customer) -> Customer:
-        logger.debug(f"Creating customer with URL: {BASEURL}/customer/create")
-        response = self._request(f"{BASEURL}/customer/create", method="POST", json=customer.model_dump())
+        logger.debug(f"Creating customer with URL: {BASE_URL}/customer/create")
+        response = self._request(f"{BASE_URL}/customer/create", method="POST", json=customer.model_dump())
 
         try:
             if response.status_code == 200:
@@ -104,8 +104,8 @@ class AbacatePay:
             raise APIConnectionError(message="Connection error", request=response)
 
     def list_customers(self) -> list[Customer]:
-        logger.debug(f"Listing customers with URL: {BASEURL}/customer/list")
-        response = self._request(f"{BASEURL}/customer/list", method="GET")
+        logger.debug(f"Listing customers with URL: {BASE_URL}/customer/list")
+        response = self._request(f"{BASE_URL}/customer/list", method="GET")
 
         try:
             if response.status_code == 200:

--- a/abacatepay/__init__.py
+++ b/abacatepay/__init__.py
@@ -22,7 +22,7 @@ from typing import Literal
 
 from .billing import Billing
 from ._models import Product, BillingResponse, Customer
-from ._constants import BILLING_KINDS, BILLING_METHODS, BASE_URL, USERAGENT
+from ._constants import BILLING_KINDS, BILLING_METHODS, BASE_URL, USER_AGENT
 from ._exceptions import *
 
 
@@ -48,7 +48,7 @@ class AbacatePay:
             url,
             headers={
                 "Authorization": f"Bearer {self.__api_key}",
-                "User-Agent": USERAGENT,
+                "User-Agent": USER_AGENT,
             },
             **kwargs,
         )

--- a/abacatepay/_constants.py
+++ b/abacatepay/_constants.py
@@ -1,7 +1,7 @@
 from typing import Literal
 
 MINIMUM_VALUE = 100
-BASEURL = "https://api.abacatepay.com/v1"
+BASE_URL = "https://api.abacatepay.com/v1"
 VERSION = "1.0.0"
 USERAGENT = f"Python SDK {VERSION}"
 

--- a/abacatepay/_constants.py
+++ b/abacatepay/_constants.py
@@ -3,7 +3,7 @@ from typing import Literal
 MINIMUM_VALUE = 100
 BASE_URL = "https://api.abacatepay.com/v1"
 VERSION = "1.0.0"
-USERAGENT = f"Python SDK {VERSION}"
+USER_AGENT = f"Python SDK {VERSION}"
 
 BILLING_STATUS = Literal['PENDING', 'EXPIRED', 'CANCELLED', 'PAID', 'REFUNDED']
 BILLING_METHODS = Literal['pix']

--- a/abacatepay/billing.py
+++ b/abacatepay/billing.py
@@ -1,6 +1,6 @@
 import requests
 from ._constants import (
-    BASEURL,
+    BASE_URL,
     USERAGENT,
     BILLING_KINDS,
     BILLING_METHODS,
@@ -28,7 +28,7 @@ class Billing:
         self.methods = methods
 
         response = requests.post(
-            f"{BASEURL}/billing/create",
+            f"{BASE_URL}/billing/create",
             json={
                 "products": [product.model_dump() for product in products],
                 "returnUrl": returnURL,

--- a/abacatepay/billing.py
+++ b/abacatepay/billing.py
@@ -1,7 +1,7 @@
 import requests
 from ._constants import (
     BASE_URL,
-    USERAGENT,
+    USER_AGENT,
     BILLING_KINDS,
     BILLING_METHODS,
     BILLING_STATUS,
@@ -40,7 +40,7 @@ class Billing:
             },
             headers={
                 "Authorization": f"Bearer {api_key}",
-                "User-Agent": USERAGENT,
+                "User-Agent": USER_AGENT,
                 "Content-Type": "application/json",
             },
         )


### PR DESCRIPTION
- Renomeia `BASEURL` para `BASE_URL` em `_constants.py` e em todas as referências no código.
- Renomeia `USERAGENT` para `USER_AGENT` em `_constants.py` e nas referências associadas.
