### PR TITLE
simply and fix client interface

### DIFF
--- a/abacatepay/_base_client.py
+++ b/abacatepay/_base_client.py
@@ -1,6 +1,8 @@
 import requests
 from typing import Literal
 from ._constants import USER_AGENT
+from .utils._exceptions import raise_for_status, APITimeoutError, APIConnectionError
+
 
 class BaseClient:
     def __init__(self, api_key: str):
@@ -12,7 +14,7 @@ class BaseClient:
         method: Literal["GET", "POST", "PUT", "PATCH", "DELETE"] = "GET",
         **kwargs,
     ):
-        return requests.request(
+        request = requests.Request(
             method,
             url,
             headers={
@@ -21,3 +23,16 @@ class BaseClient:
             },
             **kwargs,
         )
+        try:
+            prepared_request = request.prepare()
+            with requests.Session() as s:
+                response = s.send(prepared_request)
+
+            raise_for_status(response)
+            return response
+
+        except requests.exceptions.Timeout:
+            raise APITimeoutError(request=request)
+
+        except requests.exceptions.ConnectionError:
+            raise APIConnectionError(message="Connection error.", request=request)

--- a/abacatepay/billing.py
+++ b/abacatepay/billing.py
@@ -1,13 +1,7 @@
-import requests
 from ._constants import (
     BASE_URL,
     BILLING_KINDS,
     BILLING_METHODS,
-)
-from .utils._exceptions import (
-    APITimeoutError,
-    APIConnectionError,
-    raise_for_status
 )
 from .models import (
     Product,
@@ -62,18 +56,8 @@ class BillingClient(BaseClient):
             }
         )
 
-        try:
-            if response.status_code == 200:
-                billing_data = BillingResponse(data=response.json()["data"])
-                return billing_data
-            raise_for_status(response)
-
-        except requests.exceptions.Timeout:
-            raise APITimeoutError(request=response)
-
-        except requests.exceptions.ConnectionError:
-            raise APIConnectionError(message="Connection error.", request=response)
-
+        billing_data = BillingResponse(data=response.json()["data"])
+        return billing_data
 
     def list(self) -> list[BillingResponse]:
         """
@@ -84,13 +68,4 @@ class BillingClient(BaseClient):
         """
         logger.debug(f"Listing bills with URL: {BASE_URL}/billing/list")
         response = self._request(f"{BASE_URL}/billing/list", method="GET")
-
-        try:
-            if response.status_code == 200:
-                return [BillingResponse(data=bill) for bill in response.json()["data"]]
-            else:
-                raise_for_status(response)
-        except requests.exceptions.Timeout:
-            raise APITimeoutError(request=response)
-        except requests.exceptions.ConnectionError:
-            raise APIConnectionError(message="Connection error", request=response)
+        return [BillingResponse(data=bill) for bill in response.json()["data"]]

--- a/abacatepay/customers.py
+++ b/abacatepay/customers.py
@@ -1,43 +1,20 @@
 from ._constants import (
     BASE_URL,
 )
-from .utils._exceptions import (
-    APIConnectionError,
-    APITimeoutError,
-    raise_for_status
-)
 from .models import Customer
 from ._base_client import BaseClient
 from logging import getLogger
-import requests
 
 logger = getLogger(__name__)
+
 
 class CustomerClient(BaseClient):
     def create(self, customer: Customer) -> Customer:
         logger.debug(f"Creating customer with URL: {BASE_URL}/customer/create")
         response = self._request(f"{BASE_URL}/customer/create", method="POST", json=customer.model_dump())
-
-        try:
-            if response.status_code == 200:
-                return Customer.from_dict(data=response.json()["data"])
-            else:
-                raise_for_status(response)
-        except requests.exceptions.Timeout:
-            raise APITimeoutError(request=response)
-        except requests.exceptions.ConnectionError:
-            raise APIConnectionError(message="Connection error", request=response)
-
+        return Customer.from_dict(data=response.json()["data"])
 
     def list(self) -> list[Customer]:
-      logger.debug(f"Listing customers with URL: {BASE_URL}/customer/list")
-      response = self._request(f"{BASE_URL}/customer/list", method="GET")
-      try:
-          if response.status_code == 200:
-              return [Customer.from_dict(data=bill) for bill in response.json()["data"]]
-          else:
-              raise_for_status(response)
-      except requests.exceptions.Timeout:
-          raise APITimeoutError(request=response)
-      except requests.exceptions.ConnectionError:
-          raise APIConnectionError(message="Connection error", request=response)
+        logger.debug(f"Listing customers with URL: {BASE_URL}/customer/list")
+        response = self._request(f"{BASE_URL}/customer/list", method="GET")
+        return [Customer.from_dict(data=bill) for bill in response.json()["data"]]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,11 +1,11 @@
 import pytest
 from abacatepay import AbacatePay
-from abacatepay.utils._exceptions import ForbiddenRequest
+from abacatepay.utils._exceptions import UnauthorizedRequest
 
 
 def test_wrong_key_running_function(invalid_token_response):
     rightKey = "Bearer 123456789"
 
     client = AbacatePay(rightKey)
-    with pytest.raises(ForbiddenRequest):
+    with pytest.raises(UnauthorizedRequest):
         client.billing.list()

--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -1,0 +1,62 @@
+from http import HTTPStatus as status
+
+import pytest
+from requests import Response
+from requests.exceptions import ConnectionError, Timeout
+
+from abacatepay._base_client import BaseClient
+from abacatepay.utils._exceptions import (
+    APIConnectionError,
+    APIError,
+    APITimeoutError,
+    BadRequestError,
+    ForbiddenRequest,
+    InternalServerError,
+    NotFoundError,
+    UnauthorizedRequest,
+)
+
+url = "https://api.abacatepay.com/v1/billing/list"
+client = BaseClient('fake-api-key')
+
+
+def test_request_return_the_response_if_status_200(responses):
+    responses.add(
+        responses.GET,
+        url,
+        status=status.OK,
+    )
+
+    response = client._request(url, "GET")
+
+    assert response is not None
+    assert isinstance(response, Response)
+
+
+@pytest.mark.parametrize('status_code,exc_classname', [
+    (status.BAD_REQUEST, BadRequestError),
+    (status.FORBIDDEN, ForbiddenRequest),
+    (status.UNAUTHORIZED, UnauthorizedRequest),
+    (status.NOT_FOUND, NotFoundError),
+    (status.INTERNAL_SERVER_ERROR, InternalServerError),
+    (status.IM_A_TEAPOT, APIError)
+])
+def test_request_raise_the_correct_exception_when_status_is_different_of_200(responses, exc_classname, status_code):
+    responses.add(
+        responses.GET,
+        url,
+        status=status_code,
+    )
+    
+    with pytest.raises(exc_classname):
+        client._request(url, "GET")
+
+
+@pytest.mark.parametrize('requests_exc_class,api_exc_class', [
+    (Timeout, APITimeoutError),
+    (ConnectionError, APIConnectionError),
+])
+def test_request_override_requests_timeout_and_connection_error(mocker, requests_exc_class, api_exc_class):
+    mocker.patch('abacatepay._base_client.requests.Session.send', side_effect=requests_exc_class)
+    with pytest.raises(api_exc_class):
+        client._request(url, "GET")


### PR DESCRIPTION
**Feature:**  
- Centralized exception handling in the base `Client` class to simplify the `_request` method call.  

**Fix:**  
- `_request` method calls were outside the `try/except` block, so timeout and connection exceptions were not handled. To fix this, the request had to be prepared using the `Request` class and a session had to be created instead of using the `request` method, as it performs the request immediately when called.  

- Indentation difference in the `list` method of the `CustomerClient` class.  

- The status codes `401` and `403` were swapped in the `raise_for_status` function, so I corrected them.  

- Refactored the `raise_for_status` function to use a dictionary to reduce `if` statements.